### PR TITLE
Update find command to apply period insensitivity in facebook  field

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -268,6 +268,7 @@ Examples:
 Format: `find PREFIX/KEYWORD`
 
 * The search is case-insensitive. e.g. `hans` will match `Hans`.
+* For `fb/` and `ig/`, the search is period-insensitive. e.g. `find fb/johndoe` can match `john.doe`.
 * Limits the search to a single specified field.
 * Allows searching with multiple prefixes.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -268,7 +268,7 @@ Examples:
 Format: `find PREFIX/KEYWORD`
 
 * The search is case-insensitive. e.g. `hans` will match `Hans`.
-* For `fb/` and `ig/`, the search is period-insensitive. e.g. `find fb/johndoe` can match `john.doe`.
+* For `fb/`, the search is period-insensitive. e.g. `find fb/johndoe` can match `john.doe`.
 * Limits the search to a single specified field.
 * Allows searching with multiple prefixes.
 

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -53,8 +53,8 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
         String lowerPhrase = searchPhrase.toLowerCase();
         return person.getName().fullName.toLowerCase().contains(lowerPhrase)
                 || person.getPhone().map(p -> p.value.toLowerCase().contains(lowerPhrase)).orElse(false)
-                || person.getFacebook().map(fb -> fb.value.toLowerCase().contains(lowerPhrase)).orElse(false)
-                || person.getInstagram().map(ig -> ig.value.toLowerCase().contains(lowerPhrase)).orElse(false)
+                || person.getFacebook().map(fb -> containsCleanPhrase(fb.value, searchPhrase)).orElse(false)
+                || person.getInstagram().map(ig -> containsCleanPhrase(ig.value, searchPhrase)).orElse(false)
                 || person.getAddress().map(a -> a.value.toLowerCase().contains(lowerPhrase)).orElse(false)
                 || person.getRemark().map(r -> r.value.toLowerCase().contains(lowerPhrase)).orElse(false)
                 || person.getTags().stream()

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -89,16 +89,15 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
 
         if (specificKeywords.containsKey(SearchType.FACEBOOK)) {
             String val = specificKeywords.get(SearchType.FACEBOOK);
-            String cleanVal = val.startsWith("@") ? val.substring(1) : val;
             predicateList.add(p -> p.getFacebook().map(fb ->
-                    fb.value.toLowerCase().contains(cleanVal.toLowerCase())).orElse(false));
+                    containsCleanPhrase(fb.value, val)).orElse(false));
         }
 
         if (specificKeywords.containsKey(SearchType.INSTAGRAM)) {
             String val = specificKeywords.get(SearchType.INSTAGRAM);
-            String cleanVal = val.startsWith("@") ? val.substring(1) : val;
+            String cleanVal = cleanPhrase(val);
             predicateList.add(p -> p.getInstagram().map(ig ->
-                    ig.value.toLowerCase().contains(cleanVal.toLowerCase())).orElse(false));
+                    containsCleanPhrase(ig.value, val)).orElse(false));
         }
 
         if (specificKeywords.containsKey(SearchType.REMARK)) {
@@ -112,6 +111,17 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
         }
 
         return predicateList.stream().allMatch(p -> p.test(customer));
+    }
+
+    private static String cleanPhrase(String phrase) {
+        return phrase.replace("@", "").replace(".", "")
+                .replace("_", "").toLowerCase();
+    }
+
+    private static boolean containsCleanPhrase(String storedValue, String phrase) {
+        String cleanStoredValue = cleanPhrase(storedValue);
+        String cleanPhrase = cleanPhrase(phrase);
+        return cleanStoredValue.contains(cleanPhrase);
     }
 
     public String getSummary() {

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -54,7 +54,7 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
         return person.getName().fullName.toLowerCase().contains(lowerPhrase)
                 || person.getPhone().map(p -> p.value.toLowerCase().contains(lowerPhrase)).orElse(false)
                 || person.getFacebook().map(fb -> containsCleanPhrase(fb.value, searchPhrase)).orElse(false)
-                || person.getInstagram().map(ig -> containsCleanPhrase(ig.value, searchPhrase)).orElse(false)
+                || person.getInstagram().map(ig -> ig.value.toLowerCase().contains(lowerPhrase)).orElse(false)
                 || person.getAddress().map(a -> a.value.toLowerCase().contains(lowerPhrase)).orElse(false)
                 || person.getRemark().map(r -> r.value.toLowerCase().contains(lowerPhrase)).orElse(false)
                 || person.getTags().stream()

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -95,9 +95,9 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
 
         if (specificKeywords.containsKey(SearchType.INSTAGRAM)) {
             String val = specificKeywords.get(SearchType.INSTAGRAM);
-            String cleanVal = cleanPhrase(val);
+            String cleanVal = val.startsWith("@") ? val.substring(1) : val;
             predicateList.add(p -> p.getInstagram().map(ig ->
-                    containsCleanPhrase(ig.value, val)).orElse(false));
+                    ig.value.toLowerCase().contains(cleanVal.toLowerCase())).orElse(false));
         }
 
         if (specificKeywords.containsKey(SearchType.REMARK)) {
@@ -114,8 +114,7 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
     }
 
     private static String cleanPhrase(String phrase) {
-        return phrase.replace("@", "").replace(".", "")
-                .replace("_", "").toLowerCase();
+        return phrase.replace("@", "").replace(".", "").toLowerCase();
     }
 
     private static boolean containsCleanPhrase(String storedValue, String phrase) {

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -148,10 +148,26 @@ public class PersonContainsKeywordsPredicateTest {
                         PersonContainsKeywordsPredicate.SearchType.FACEBOOK, "randomFbAccount"));
         assertTrue(predicate.test(new PersonBuilder().withFacebook("randomFbAccount").build()));
 
+        predicate = new PersonContainsKeywordsPredicate("fb/@lebron.james", false,
+                createMap(PersonContainsKeywordsPredicate.SearchType.FACEBOOK, "lebron.james"));
+        assertTrue(predicate.test(new PersonBuilder().withFacebook("LebronJames").build()));
+
+        predicate = new PersonContainsKeywordsPredicate("fb/ALEX1234", false,
+                createMap(PersonContainsKeywordsPredicate.SearchType.FACEBOOK, "ALEX1234"));
+        assertTrue(predicate.test(new PersonBuilder().withFacebook("Alex.1234").build()));
+
         predicate = new PersonContainsKeywordsPredicate("ig/randomIgAccount",
                 false, createMap(
                 PersonContainsKeywordsPredicate.SearchType.INSTAGRAM, "randomIgAccount"));
         assertTrue(predicate.test(new PersonBuilder().withInstagram("randomIgAccount").build()));
+
+        predicate = new PersonContainsKeywordsPredicate("ig/ALEX1234", false,
+                createMap(PersonContainsKeywordsPredicate.SearchType.INSTAGRAM, "ALEX1234"));
+        assertTrue(predicate.test(new PersonBuilder().withInstagram("Alex.1234").build()));
+
+        predicate = new PersonContainsKeywordsPredicate("ig/@Bernice_Yu", false,
+                createMap(PersonContainsKeywordsPredicate.SearchType.INSTAGRAM, "@Bernice_Yu"));
+        assertTrue(predicate.test(new PersonBuilder().withInstagram("BerniceYu").build()));
 
         predicate = new PersonContainsKeywordsPredicate("r/VIP",
                 false, createMap(

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -100,6 +100,22 @@ public class PersonContainsKeywordsPredicateTest {
         PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(
                 "alice.pau", true, new HashMap<>());
         assertTrue(predicate.test(new PersonBuilder().withFacebook("alice.pauline").build()));
+
+        predicate = new PersonContainsKeywordsPredicate(
+                "@alice.pau", true, new HashMap<>());
+        assertTrue(predicate.test(new PersonBuilder().withFacebook("alicepauline").build()));
+
+    }
+
+    @Test
+    public void test_InstagramContainsPhrase_returnsTrue() {
+        PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(
+                "charlie_1234", true, new HashMap<>());
+        assertTrue(predicate.test(new PersonBuilder().withInstagram("charlie_1234").build()));
+
+        predicate = new PersonContainsKeywordsPredicate(
+                "@charlie_1234", true, new HashMap<>());
+        assertTrue(predicate.test(new PersonBuilder().withInstagram("charlie1234").build()));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -112,10 +112,6 @@ public class PersonContainsKeywordsPredicateTest {
         PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(
                 "charlie_1234", true, new HashMap<>());
         assertTrue(predicate.test(new PersonBuilder().withInstagram("charlie_1234").build()));
-
-        predicate = new PersonContainsKeywordsPredicate(
-                "@charlie_1234", true, new HashMap<>());
-        assertTrue(predicate.test(new PersonBuilder().withInstagram("charlie1234").build()));
     }
 
     @Test
@@ -177,13 +173,9 @@ public class PersonContainsKeywordsPredicateTest {
                 PersonContainsKeywordsPredicate.SearchType.INSTAGRAM, "randomIgAccount"));
         assertTrue(predicate.test(new PersonBuilder().withInstagram("randomIgAccount").build()));
 
-        predicate = new PersonContainsKeywordsPredicate("ig/ALEX1234", false,
-                createMap(PersonContainsKeywordsPredicate.SearchType.INSTAGRAM, "ALEX1234"));
-        assertTrue(predicate.test(new PersonBuilder().withInstagram("Alex.1234").build()));
-
         predicate = new PersonContainsKeywordsPredicate("ig/@Bernice_Yu", false,
                 createMap(PersonContainsKeywordsPredicate.SearchType.INSTAGRAM, "@Bernice_Yu"));
-        assertTrue(predicate.test(new PersonBuilder().withInstagram("BerniceYu").build()));
+        assertTrue(predicate.test(new PersonBuilder().withInstagram("Bernice_Yu").build()));
 
         predicate = new PersonContainsKeywordsPredicate("r/VIP",
                 false, createMap(

--- a/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/PersonContainsKeywordsPredicateTest.java
@@ -108,7 +108,7 @@ public class PersonContainsKeywordsPredicateTest {
     }
 
     @Test
-    public void test_InstagramContainsPhrase_returnsTrue() {
+    public void test_instagramContainsPhrase_returnsTrue() {
         PersonContainsKeywordsPredicate predicate = new PersonContainsKeywordsPredicate(
                 "charlie_1234", true, new HashMap<>());
         assertTrue(predicate.test(new PersonBuilder().withInstagram("charlie_1234").build()));


### PR DESCRIPTION
Update find command for both specific and general search

Facebook and Ig are now period-insensitive

E.g, "find fb/Bernice.Yu" can find customer whose facebook username is "berniceyu"
"find ig/alexyeoh" can find customer whose ig username is "alex.yeoh"


close #264