### PR TITLE
Fix unintended clearing of result display box and enhance error messages

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -36,6 +36,8 @@ public class Messages {
             "Customer has no saved address. Please specify delivery address with a/ or use a/PICKUP for pickup orders.";
     public static final String MESSAGE_UNSUPPORTED_PREFIX =
             "Unsupported prefix '%1$s' in this command. Valid prefixes: n/, p/, fb/, ig/, a/, r/, t/.";
+    public static final String MESSAGE_UNSUPPORTED_ORDER_PREFIX =
+            "Unsupported prefix '%1$s' in this command. Valid prefixes: i/, q/, at/, a/, s/.";
 
     public static final String MESSAGE_WARNING_DUPLICATE_CONTACT = "WARNING: Duplicate contact details detected. "
             + "This is allowed, but please verify.%nMatched fields: %s%n%s%n%n";

--- a/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddOrderCommandParser.java
@@ -13,6 +13,7 @@ import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddOrderCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.order.DeliveryTime;
@@ -68,8 +69,22 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
         logger.log(Level.FINE, "Parsing item, quantity, and delivery time");
 
         Item item = ParserUtil.parseItem(argMultimap.getValue(PREFIX_ITEM).get());
-        Quantity quantity = ParserUtil.parseQuantity(argMultimap.getValue(PREFIX_QUANTITY).get());
-        DeliveryTime deliveryTime = ParserUtil.parseDeliveryTime(argMultimap.getValue(PREFIX_DATETIME).get());
+
+        String qtyValue = argMultimap.getValue(PREFIX_QUANTITY).get();
+        qtyValue = ParserUtil.ensureNoUnsupportedPrefixTokensInValue(
+                qtyValue,
+                Messages.MESSAGE_UNSUPPORTED_ORDER_PREFIX,
+                ParserUtil.PREFIXES_FOR_ORDER_COMMAND
+        );
+        Quantity quantity = ParserUtil.parseQuantity(qtyValue);
+
+        String dtValue = argMultimap.getValue(PREFIX_DATETIME).get();
+        dtValue = ParserUtil.ensureNoUnsupportedPrefixTokensInValue(
+                dtValue,
+                Messages.MESSAGE_UNSUPPORTED_ORDER_PREFIX,
+                ParserUtil.PREFIXES_FOR_ORDER_COMMAND
+        );
+        DeliveryTime deliveryTime = ParserUtil.parseDeliveryTime(dtValue);
 
         boolean isPast = !deliveryTime.isInFuture();
 
@@ -78,10 +93,19 @@ public class AddOrderCommandParser implements Parser<AddOrderCommand> {
                 ? Optional.of(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()))
                 : Optional.empty();
 
-        Optional<Status> status = argMultimap.getValue(PREFIX_STATUS)
-                .isPresent()
-                ? Optional.of(ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get()))
-                : Optional.empty();
+        Optional<Status> status = Optional.empty();
+
+        if (argMultimap.getValue(PREFIX_STATUS).isPresent()) {
+            String rawStatusValue = argMultimap.getValue(PREFIX_STATUS).get();
+
+            ParserUtil.ensureNoUnsupportedPrefixTokensInValue(
+                    rawStatusValue,
+                    Messages.MESSAGE_UNSUPPORTED_ORDER_PREFIX,
+                    ParserUtil.PREFIXES_FOR_ORDER_COMMAND
+            );
+
+            status = Optional.of(ParserUtil.parseStatus(rawStatusValue));
+        }
 
         logger.log(Level.INFO, "Successfully parsed AddOrderCommand");
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -52,10 +52,10 @@ public class ParserUtil {
     };
 
     /**
-     * Prefixes recognised by {@code order} and {@code edit-o} for orders (used to detect stray {@code x/}-style tokens).
+     * Prefixes recognised by {@code order} (used to detect stray {@code x/}-style tokens).
      */
     public static final Prefix[] PREFIXES_FOR_ORDER_COMMAND = {
-            PREFIX_ITEM, PREFIX_QUANTITY, PREFIX_DATETIME, PREFIX_ADDRESS, PREFIX_STATUS
+        PREFIX_ITEM, PREFIX_QUANTITY, PREFIX_DATETIME, PREFIX_ADDRESS, PREFIX_STATUS
     };
 
     private static final Pattern EMBEDDED_PREFIX_LIKE_TOKEN = Pattern.compile("\\s+([a-zA-Z][a-zA-Z0-9]*)/");

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,11 +2,15 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FACEBOOK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSTAGRAM;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ITEM;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_QUANTITY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
@@ -47,6 +51,13 @@ public class ParserUtil {
         PREFIX_NAME, PREFIX_PHONE, PREFIX_FACEBOOK, PREFIX_INSTAGRAM, PREFIX_ADDRESS, PREFIX_REMARK, PREFIX_TAG
     };
 
+    /**
+     * Prefixes recognised by {@code order} and {@code edit-o} for orders (used to detect stray {@code x/}-style tokens).
+     */
+    public static final Prefix[] PREFIXES_FOR_ORDER_COMMAND = {
+            PREFIX_ITEM, PREFIX_QUANTITY, PREFIX_DATETIME, PREFIX_ADDRESS, PREFIX_STATUS
+    };
+
     private static final Pattern EMBEDDED_PREFIX_LIKE_TOKEN = Pattern.compile("\\s+([a-zA-Z][a-zA-Z0-9]*)/");
 
     /**
@@ -65,6 +76,34 @@ public class ParserUtil {
             String token = m.group(1) + "/";
             if (!allowed.contains(token)) {
                 throw new ParseException(String.format(Messages.MESSAGE_UNSUPPORTED_PREFIX, token));
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Ensures {@code value} does not contain any substring that resembles an
+     * unsupported prefix token (e.g. {@code x/hello}) that is not one of the
+     * given {@code allowedPrefixes}. Uses {@code errorMessage} when reporting
+     * unsupported prefixes.
+     *
+     * @return {@code value} unchanged, allowing convenient chaining into {@code parseX} methods
+     */
+    public static String ensureNoUnsupportedPrefixTokensInValue(
+            String value, String errorMessage, Prefix... allowedPrefixes
+    ) throws ParseException {
+        requireNonNull(value);
+        requireNonNull(allowedPrefixes);
+
+        Set<String> allowed = Arrays.stream(allowedPrefixes)
+                .map(Prefix::getPrefix)
+                .collect(Collectors.toSet());
+
+        Matcher m = EMBEDDED_PREFIX_LIKE_TOKEN.matcher(value);
+        while (m.find()) {
+            String token = m.group(1) + "/";
+            if (!allowed.contains(token)) {
+                throw new ParseException(String.format(errorMessage, token));
             }
         }
         return value;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -23,6 +23,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class MainWindow extends UiPart<Stage> {
 
+    public static final String STARTUP_ORDER_FILTER_MESSAGE =
+            "Displaying only active orders (PREPARING / READY). Use 'list-o' to view all orders.";
+
     private static final String FXML = "MainWindow.fxml";
     private static final String ORDER_COMMAND_ADD = "order";
     private static final String ORDER_COMMAND_EDIT = "edit-o";
@@ -125,7 +128,10 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList(), logic,
                 person -> {
                     orderListPanel.setOrdersContext(person);
-                    resultDisplay.setFeedbackToUser("");
+
+                    if (resultDisplay.getFeedbackToUser().equals(STARTUP_ORDER_FILTER_MESSAGE)) {
+                        resultDisplay.setFeedbackToUser("");
+                    }
                 });
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 

--- a/src/main/java/seedu/address/ui/ResultDisplay.java
+++ b/src/main/java/seedu/address/ui/ResultDisplay.java
@@ -29,4 +29,7 @@ public class ResultDisplay extends UiPart<Region> {
         resultDisplay.setText(feedbackToUser);
     }
 
+    public String getFeedbackToUser() {
+        return resultDisplay.getText();
+    }
 }

--- a/src/main/java/seedu/address/ui/UiManager.java
+++ b/src/main/java/seedu/address/ui/UiManager.java
@@ -43,9 +43,7 @@ public class UiManager implements Ui {
             mainWindow = new MainWindow(primaryStage, logic);
             mainWindow.show(); //This should be called before creating other UI parts
             mainWindow.fillInnerParts();
-            mainWindow.setFeedbackToUser(
-                    "Displaying only active orders (PREPARING / READY) . Use 'list-o' to view all orders."
-            );
+            mainWindow.setFeedbackToUser(MainWindow.STARTUP_ORDER_FILTER_MESSAGE);
 
         } catch (Throwable e) {
             logger.severe(StringUtil.getDetails(e));


### PR DESCRIPTION
previously, result display box clears whenever a customer card is clicked on, now it clears only if the message shown is the app startup message